### PR TITLE
Enable feed

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,3 +23,5 @@ defaults:
       path: en
     values:
       lang: en
+plugins:
+  - jekyll-feed

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
     <link rel="canonical" href="{{ site.url }}{{ page.url | replace: 'index.html', '' }}">
     {{ page.head }}
+    {% feed_meta %}
   </head>
   <body>
     {% capture toppage %}/{{ page.lang }}/{% endcapture %}


### PR DESCRIPTION
Hello,

This pull request enables [jekyll-feed][feed], a Jekyll plugin to generate a feed.

[feed]: https://github.com/jekyll/jekyll-feed

The generated feed is at `/feed.xml`.  And every page should have `<link type="application/atom+xml" rel="alternate" href="[https://smlsharp.github.io/feed.xml](view-source:http://localhost:4000/feed.xml)" />` in `head` tag, so that some RSS readers can detect it.

The plugin is included in the [GitHub Pages Dependency versions][vers] (equivallently `github-pages` gem has `jekyll-feed` as its dependency), so I believe it works.

[vers]: https://pages.github.com/versions/

I couldn't find out how to generate par-language feeds.  Currently both Japanese and English posts are listed in a single feed file.  I wish there were `/ja/feed.xml` and `/en/feed.xml` in the future, but I think it's better to have than nothing.

Regards.